### PR TITLE
pkg/auth/userinfo/gitdb: add UserInfo.GetUsersInGroups() method.

### DIFF
--- a/pkg/auth/userinfo/gitdb/api.go
+++ b/pkg/auth/userinfo/gitdb/api.go
@@ -25,6 +25,10 @@ func (uinfo *UserInfo) GetUserGroups(username string, groupPrefix *string) (
 	return uinfo.getUserGroups(username, groupPrefix)
 }
 
+func (uinfo *UserInfo) GetUsersInGroups() ([]string, error) {
+	return uinfo.getUsersInGroups()
+}
+
 func (uinfo *UserInfo) TestUserInGroup(username, groupname string) bool {
 	return uinfo.testUserInGroup(username, groupname)
 }


### PR DESCRIPTION
Also support multiple instances of UserInfo by preventing collisions in the
metrics namespace.