### PR TITLE
Improve auth/userinfo packages.

### DIFF
--- a/pkg/auth/userinfo/api.go
+++ b/pkg/auth/userinfo/api.go
@@ -1,10 +1,15 @@
 package userinfo
 
-// UserInfo is the interface that wraps the GetUserGroups method.
+// UserGroupsGetter is the interface that wraps the GetUserGroups method.
 //
 // GetUserGroups gets the groups that the user specified by username is a member
-// of. If groupPrefix is not nil, only groups which have this prefix will be
-// returned and the prefix will be stripped from these groups.
+// of.
+type UserGroupsGetter interface {
+	GetUserGroups(username string) ([]string, error)
+}
+
+// UserInfo is the interface that wraps multiple methods which yield information
+// about a user.
 type UserInfo interface {
-	GetUserGroups(username string, groupPrefix *string) ([]string, error)
+	UserGroupsGetter
 }

--- a/pkg/auth/userinfo/filter/api.go
+++ b/pkg/auth/userinfo/filter/api.go
@@ -1,0 +1,35 @@
+package filter
+
+import (
+	"regexp"
+
+	"github.com/Cloud-Foundations/golib/pkg/auth/userinfo"
+)
+
+type UserGroupsInfo struct {
+	re               *regexp.Regexp
+	userGroupsGetter userinfo.UserGroupsGetter
+}
+
+type UserInfo struct {
+	UserGroupsInfo
+	userinfo.UserInfo
+}
+
+func NewUserGroupsFilter(userGroups userinfo.UserGroupsGetter,
+	regex string) (userinfo.UserGroupsGetter, error) {
+	return newUserGroupsFilter(userGroups, regex)
+}
+
+func (uinfo *UserGroupsInfo) GetUserGroups(username string) ([]string, error) {
+	return uinfo.getUserGroups(username)
+}
+
+func NewUserInfoFilter(userInfo userinfo.UserInfo,
+	groupFilter string) (userinfo.UserInfo, error) {
+	return newUserInfoFilter(userInfo, groupFilter)
+}
+
+func (uinfo *UserInfo) GetUserGroups(username string) ([]string, error) {
+	return uinfo.UserGroupsInfo.GetUserGroups(username)
+}

--- a/pkg/auth/userinfo/filter/impl.go
+++ b/pkg/auth/userinfo/filter/impl.go
@@ -1,0 +1,57 @@
+package filter
+
+import (
+	"regexp"
+
+	"github.com/Cloud-Foundations/golib/pkg/auth/userinfo"
+)
+
+func newUserGroupsFilter(userGroups userinfo.UserGroupsGetter,
+	regex string) (userinfo.UserGroupsGetter, error) {
+	if regex == "" {
+		return userGroups, nil
+	}
+	if re, err := regexp.Compile(regex); err != nil {
+		return nil, err
+	} else {
+		return &UserGroupsInfo{
+			re:               re,
+			userGroupsGetter: userGroups,
+		}, nil
+	}
+}
+
+func newUserInfoFilter(userInfo userinfo.UserInfo,
+	groupFilter string) (userinfo.UserInfo, error) {
+	if groupFilter == "" {
+		return userInfo, nil
+	}
+	if re, err := regexp.Compile(groupFilter); err != nil {
+		return nil, err
+	} else {
+		return &UserInfo{
+			UserGroupsInfo: UserGroupsInfo{
+				re:               re,
+				userGroupsGetter: userInfo,
+			},
+			UserInfo: userInfo,
+		}, nil
+	}
+}
+
+func (uinfo *UserGroupsInfo) getUserGroups(username string) ([]string, error) {
+	groups, err := uinfo.userGroupsGetter.GetUserGroups(username)
+	if err != nil {
+		return nil, err
+	}
+	outputGroups := make([]string, 0, len(groups))
+	for _, group := range groups {
+		if uinfo.re.MatchString(group) {
+			output := uinfo.re.ReplaceAllString(group, "")
+			if output != "" {
+				outputGroups = append(outputGroups, output)
+			}
+		}
+	}
+	return outputGroups, nil
+}

--- a/pkg/auth/userinfo/filter/impl_test.go
+++ b/pkg/auth/userinfo/filter/impl_test.go
@@ -1,0 +1,92 @@
+package filter
+
+import (
+	"fmt"
+	"testing"
+)
+
+type groupLister []string
+
+var (
+	inputGroups = groupLister{
+		"AWS-IAM-Dev-Admin",
+		"AWS-IAM-Dev-Engineer",
+		"GCP-IAM-Prod-Admin",
+		"GCP-IAM-Prod-Engineer",
+	}
+)
+
+func (gl groupLister) GetUserGroups(username string) ([]string, error) {
+	return gl, nil
+}
+
+func TestNoFilter(t *testing.T) {
+	uinfo, err := NewUserGroupsFilter(inputGroups, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	groups, err := uinfo.GetUserGroups("user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(groups) != len(inputGroups) {
+		t.Fatalf("%d output groups != %d input groups",
+			len(groups), len(inputGroups))
+	}
+	if groups[0] != inputGroups[0] {
+		t.Errorf("expected: %s, got: %s", inputGroups[0], groups[0])
+	}
+}
+
+func testFilter(input, regex, expected string) error {
+	uinfo, err := NewUserGroupsFilter(groupLister{input}, regex)
+	if err != nil {
+		return err
+	}
+	groups, err := uinfo.GetUserGroups("user")
+	if err != nil {
+		return err
+	}
+	if expected == "" {
+		if len(groups) == 0 {
+			return nil
+		}
+		return fmt.Errorf("expected nothing, got: %v", groups)
+	}
+	if len(groups) != 1 {
+		return fmt.Errorf("%d output groups != 1 input group", len(groups))
+	}
+	if groups[0] != expected {
+		return fmt.Errorf("input: %s, output: %s != expected: %s",
+			input, groups[0], expected)
+	}
+	return nil
+}
+
+func TestFrontFilter(t *testing.T) {
+	err := testFilter("AWS-IAM-Dev-Admin", "^AWS-IAM-", "Dev-Admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMiddleFilter(t *testing.T) {
+	err := testFilter("team-JUNK-name", "-JUNK", "team-name")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRearFilter(t *testing.T) {
+	err := testFilter("team-name-junk", "-junk$", "team-name")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUnmatchedFilter(t *testing.T) {
+	err := testFilter("GCP-IAM-Dev-Admin", "^AWS-IAM-", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/auth/userinfo/gitdb/api.go
+++ b/pkg/auth/userinfo/gitdb/api.go
@@ -20,9 +20,8 @@ func New(repositoryURL, branch, localRepositoryDir string,
 		logger)
 }
 
-func (uinfo *UserInfo) GetUserGroups(username string, groupPrefix *string) (
-	[]string, error) {
-	return uinfo.getUserGroups(username, groupPrefix)
+func (uinfo *UserInfo) GetUserGroups(username string) ([]string, error) {
+	return uinfo.getUserGroups(username)
 }
 
 func (uinfo *UserInfo) GetUsersInGroups() ([]string, error) {

--- a/pkg/auth/userinfo/gitdb/impl.go
+++ b/pkg/auth/userinfo/gitdb/impl.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/Cloud-Foundations/Dominator/lib/decoders"
@@ -186,8 +185,7 @@ func (loadState *loadStateType) processGroup(group *groupType,
 	group.users = userList
 }
 
-func (uinfo *UserInfo) getUserGroups(username string, groupPrefix *string) (
-	[]string, error) {
+func (uinfo *UserInfo) getUserGroups(username string) ([]string, error) {
 	uinfo.rwMutex.RLock()
 	groupsMap := uinfo.groupsPerUser[username]
 	groups := make([]string, 0, len(groupsMap))
@@ -195,17 +193,7 @@ func (uinfo *UserInfo) getUserGroups(username string, groupPrefix *string) (
 		groups = append(groups, group)
 	}
 	uinfo.rwMutex.RUnlock()
-	if groupPrefix == nil {
-		return groups, nil
-	}
-	matchedGroups := make([]string, 0, len(groups))
-	charsToStrip := len(*groupPrefix)
-	for _, group := range groups {
-		if strings.HasPrefix(group, *groupPrefix) {
-			matchedGroups = append(matchedGroups, group[charsToStrip:])
-		}
-	}
-	return matchedGroups, nil
+	return groups, nil
 }
 
 func (uinfo *UserInfo) getUsersInGroups() ([]string, error) {

--- a/pkg/auth/userinfo/gitdb/impl_test.go
+++ b/pkg/auth/userinfo/gitdb/impl_test.go
@@ -51,7 +51,7 @@ func (uinfo *UserInfo) testDB(t *testing.T) {
 		t.Fatal("userA found in unpermitted0 using TestUserInGroup")
 	} else if len(groups) != 2 {
 		t.Fatalf("userA in %d groups, expected 2", len(groups))
-	} else if g, err := uinfo.GetUserGroups("userA", nil); err != nil {
+	} else if g, err := uinfo.GetUserGroups("userA"); err != nil {
 		t.Fatal(err)
 	} else if len(g) != 2 {
 		t.Fatalf("userA in %d groups using GetUserGroups, expected 2",

--- a/pkg/auth/userinfo/ldap/api.go
+++ b/pkg/auth/userinfo/ldap/api.go
@@ -8,22 +8,28 @@ import (
 )
 
 type UserInfo struct {
-	ldapURL           []*url.URL
-	bindUsername      string
-	bindPassword      string
-	userSearchFilter  string
-	userSearchBaseDNs []string
-	timeoutSecs       uint
-	rootCAs           *x509.CertPool
-	logger            log.DebugLogger
+	ldapURLs           []*url.URL
+	bindUsername       string
+	bindPassword       string
+	groupSearchFilter  string
+	groupSearchBaseDNs []string
+	userSearchFilter   string
+	userSearchBaseDNs  []string
+	timeoutSecs        uint
+	rootCAs            *x509.CertPool
+	logger             log.DebugLogger
 }
 
-func New(url []string, bindUsername string, bindPassword string,
-	userSearchFilter string, userSearchBaseDNs []string, timeoutSecs uint, rootCAs *x509.CertPool, logger log.DebugLogger) (
+func New(urlList []string, bindUsername string, bindPassword string,
+	groupSearchFilter string, groupSearchBaseDNs []string,
+	userSearchFilter string, userSearchBaseDNs []string,
+	timeoutSecs uint, rootCAs *x509.CertPool, logger log.DebugLogger) (
 	*UserInfo, error) {
-	return newUserInfo(url, bindUsername, bindPassword, userSearchFilter, userSearchBaseDNs, timeoutSecs, rootCAs, logger)
+	return newUserInfo(urlList, bindUsername, bindPassword,
+		groupSearchFilter, groupSearchBaseDNs,
+		userSearchFilter, userSearchBaseDNs, timeoutSecs, rootCAs, logger)
 }
 
-func (uinfo *UserInfo) GetUserGroups(username string, groupPrefix *string) ([]string, error) {
-	return uinfo.getUserGroups(username, groupPrefix)
+func (uinfo *UserInfo) GetUserGroups(username string) ([]string, error) {
+	return uinfo.getUserGroups(username)
 }


### PR DESCRIPTION
Simplify GetUserGroups() methods by removing groupPrefix parameter.
Move group filtering to auth/userinfo/filter package.
Enhance LDAP GetUserGroups() to also find users by searching groups
(i.e. for memberUid=%s).