### PR TITLE
Support storing and retrieving certificates from AWS Secrets Manager.

### DIFF
--- a/cmd/locker-test/main.go
+++ b/cmd/locker-test/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/Cloud-Foundations/Dominator/lib/flags/loadflags"
+	"github.com/Cloud-Foundations/Dominator/lib/log/cmdlogger"
+	"github.com/Cloud-Foundations/golib/pkg/crypto/certmanager"
+	"github.com/Cloud-Foundations/golib/pkg/crypto/certmanager/storage/awssecretsmanager"
+	"github.com/Cloud-Foundations/golib/pkg/log"
+)
+
+var (
+	awsSecretId = flag.String("awsSecretId", "",
+		"Optional AWS Secrets Manager SecretId to read/write certs to")
+)
+
+func doMain() int {
+	if err := loadflags.LoadForCli("locker-test"); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	flag.Usage = printUsage
+	flag.Parse()
+	if flag.NArg() != 0 {
+		printUsage()
+		return 3
+	}
+	logger := cmdlogger.New()
+	if err := runLocker(logger); err != nil {
+		logger.Println(err)
+		return 1
+	}
+	return 0
+}
+
+func main() {
+	os.Exit(doMain())
+}
+
+func printUsage() {
+	w := flag.CommandLine.Output()
+	fmt.Fprintln(w, "Usage: locker-test [flags...]")
+	fmt.Fprintln(w, "Common flags:")
+	flag.PrintDefaults()
+}
+
+func runLocker(logger log.DebugLogger) error {
+	var locker certmanager.Locker
+	if *awsSecretId != "" {
+		lockingStorer, err := awssecretsmanager.New(*awsSecretId, logger)
+		if err != nil {
+			return err
+		}
+		locker = lockingStorer
+	}
+	if locker == nil {
+		return errors.New("no locker resource specified")
+	}
+	if err := locker.Lock(); err != nil {
+		return err
+	}
+	logger.Println("waiting for control-C")
+	sigintChannel := make(chan os.Signal, 1)
+	signal.Notify(sigintChannel, syscall.SIGINT)
+	<-sigintChannel
+	logger.Println()
+	return locker.Unlock()
+}

--- a/pkg/crypto/certmanager/config/api.go
+++ b/pkg/crypto/certmanager/config/api.go
@@ -10,6 +10,7 @@ import (
 )
 
 type AcmeConfig struct {
+	AwsSecretId         string   `yaml:"aws_secret_id"`
 	ChallengeType       string   `yaml:"challenge_type"`
 	DomainNames         []string `yaml:"domain_names"`
 	HttpPort            uint16   `yaml:"http_port"`              // For http-01.

--- a/pkg/crypto/certmanager/manager.go
+++ b/pkg/crypto/certmanager/manager.go
@@ -131,6 +131,7 @@ func (cert *Certificate) parse() error {
 	if err != nil {
 		return err
 	}
+	cert.tlsCert.Leaf = x509Cert
 	cert.notAfter = x509Cert.NotAfter
 	cert.notBefore = x509Cert.NotBefore
 	return nil
@@ -265,6 +266,9 @@ func (cm *CertificateManager) checkRenew() time.Duration {
 			cm.logger.Println(err)
 		} else if expire := cert.timeUntilRenewal(cm.renewBefore); expire > 0 {
 			cm.rwMutex.Lock()
+			if cm.certificate == nil {
+				go cm.fileWrite(cert)
+			}
 			cm.certificate = cert
 			cm.rwMutex.Unlock()
 			return expire

--- a/pkg/crypto/certmanager/manager.go
+++ b/pkg/crypto/certmanager/manager.go
@@ -264,14 +264,16 @@ func (cm *CertificateManager) checkRenew() time.Duration {
 		// if it needs to be renewed.
 		if cert, err := readCert(cm.storer); err != nil {
 			cm.logger.Println(err)
-		} else if expire := cert.timeUntilRenewal(cm.renewBefore); expire > 0 {
+		} else { // Make use of a certificate, even if expired, then rewnew.
 			cm.rwMutex.Lock()
 			if cm.certificate == nil {
 				go cm.fileWrite(cert)
 			}
 			cm.certificate = cert
 			cm.rwMutex.Unlock()
-			return expire
+			if expire := cert.timeUntilRenewal(cm.renewBefore); expire > 0 {
+				return expire
+			}
 		}
 	}
 	if err := cm.renew(); err != nil {

--- a/pkg/crypto/certmanager/storage/awssecretsmanager/README.md
+++ b/pkg/crypto/certmanager/storage/awssecretsmanager/README.md
@@ -1,0 +1,24 @@
+# awssecretsmanager
+A package which implements a remote certificate+key store and a locking
+mechanism to serialise ACME transactions using AWS Secrets Manager.
+
+It is recommended to use an instance role to access the secret. The following
+IAM policies are the minimum required to read and update the secret.
+This is an example policy document statement for Terraform:
+
+```
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:PutSecretValue",
+      "secretsmanager:UpdateSecretVersionStage",
+    ]
+
+    resources = [
+      "aws_secretsmanager_secret.keymaster_x509.arn",
+    ]
+  }
+```
+
+`aws_secretsmanager_secret.keymaster_x509.arn` should expand to the ARN for the
+secret.

--- a/pkg/crypto/certmanager/storage/awssecretsmanager/api.go
+++ b/pkg/crypto/certmanager/storage/awssecretsmanager/api.go
@@ -1,0 +1,43 @@
+/*
+Package awssecretsmanager implements the Locker and Storer interfaces using
+AWS Secrets Manager.
+*/
+
+package awssecretsmanager
+
+import (
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+
+	"github.com/Cloud-Foundations/golib/pkg/crypto/certmanager"
+	"github.com/Cloud-Foundations/golib/pkg/log"
+)
+
+type LockingStorer struct {
+	awsService *secretsmanager.SecretsManager
+	logger     log.DebugLogger
+	secretId   string
+}
+
+func New(secretId string, logger log.DebugLogger) (*LockingStorer, error) {
+	return newLS(secretId, logger)
+}
+
+func (ls *LockingStorer) GetLostChannel() <-chan error {
+	return nil
+}
+
+func (ls *LockingStorer) Lock() error {
+	return ls.lock()
+}
+
+func (ls *LockingStorer) Read() (*certmanager.Certificate, error) {
+	return ls.read()
+}
+
+func (ls *LockingStorer) Unlock() error {
+	return ls.unlock()
+}
+
+func (ls *LockingStorer) Write(cert *certmanager.Certificate) error {
+	return ls.write(cert)
+}

--- a/pkg/crypto/certmanager/storage/awssecretsmanager/api.go
+++ b/pkg/crypto/certmanager/storage/awssecretsmanager/api.go
@@ -6,6 +6,8 @@ AWS Secrets Manager.
 package awssecretsmanager
 
 import (
+	"sync"
+
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 
 	"github.com/Cloud-Foundations/golib/pkg/crypto/certmanager"
@@ -13,9 +15,11 @@ import (
 )
 
 type LockingStorer struct {
-	awsService *secretsmanager.SecretsManager
-	logger     log.DebugLogger
-	secretId   string
+	awsService  *secretsmanager.SecretsManager
+	logger      log.DebugLogger
+	secretId    string
+	mutex       sync.Mutex // Protect everything below.
+	lockVersion *string
 }
 
 func New(secretId string, logger log.DebugLogger) (*LockingStorer, error) {

--- a/pkg/crypto/certmanager/storage/awssecretsmanager/impl.go
+++ b/pkg/crypto/certmanager/storage/awssecretsmanager/impl.go
@@ -125,13 +125,6 @@ func putAwsSecret(awsService *secretsmanager.SecretsManager,
 	return errors.New("no AWSCURRENT version stage associated")
 }
 
-func (ls *LockingStorer) lock() error {
-	ls.logger.Printf(
-		"UNIMPLEMENTED: locked AWS Secrets Manager, SecretId: %s\n",
-		ls.secretId)
-	return nil // HACK
-}
-
 func (ls *LockingStorer) read() (*certmanager.Certificate, error) {
 	keyMap, err := getAwsSecret(ls.awsService, ls.secretId)
 	if err != nil {
@@ -186,13 +179,6 @@ func (ls *LockingStorer) read() (*certmanager.Certificate, error) {
 		CertPemBlock: certPEM.Bytes(),
 		KeyPemBlock:  keyPEM,
 	}, nil
-}
-
-func (ls *LockingStorer) unlock() error {
-	ls.logger.Printf(
-		"UNIMPLEMENTED: unlocked AWS Secrets Manager, SecretId: %s\n",
-		ls.secretId)
-	return nil // HACK
 }
 
 func (ls *LockingStorer) write(cert *certmanager.Certificate) error {

--- a/pkg/crypto/certmanager/storage/awssecretsmanager/impl.go
+++ b/pkg/crypto/certmanager/storage/awssecretsmanager/impl.go
@@ -1,0 +1,238 @@
+package awssecretsmanager
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/Cloud-Foundations/golib/pkg/crypto/certmanager"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+
+	"github.com/Cloud-Foundations/golib/pkg/log"
+)
+
+var (
+	awsSecretsManagerLock                sync.Mutex
+	awsSecretsManagerMetadataClient      *ec2metadata.EC2Metadata
+	awsSecretsManagerMetadataClientError error
+)
+
+func getMetadataClient() (*ec2metadata.EC2Metadata, error) {
+	awsSecretsManagerLock.Lock()
+	defer awsSecretsManagerLock.Unlock()
+	if awsSecretsManagerMetadataClient != nil {
+		return awsSecretsManagerMetadataClient, nil
+	}
+	if awsSecretsManagerMetadataClientError != nil {
+		return nil, awsSecretsManagerMetadataClientError
+	}
+	metadataClient := ec2metadata.New(session.New())
+	if !metadataClient.Available() {
+		awsSecretsManagerMetadataClientError = errors.New(
+			"not running on AWS or metadata is not available")
+		return nil, awsSecretsManagerMetadataClientError
+	}
+	awsSecretsManagerMetadataClient = metadataClient
+	return awsSecretsManagerMetadataClient, nil
+}
+
+func getAwsService(secretId string) (*secretsmanager.SecretsManager, error) {
+	metadataClient, err := getMetadataClient()
+	if err != nil {
+		return nil, err
+	}
+	var region string
+	if arn, err := arn.Parse(secretId); err == nil {
+		region = arn.Region
+	} else {
+		region, err = metadataClient.Region()
+		if err != nil {
+			return nil, err
+		}
+	}
+	awsSession, err := session.NewSession(&aws.Config{
+		Region: aws.String(region),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating session: %s", err)
+	}
+	if awsSession == nil {
+		return nil, errors.New("awsSession == nil")
+	}
+	return secretsmanager.New(awsSession), nil
+}
+
+func getAwsSecret(awsService *secretsmanager.SecretsManager,
+	secretId string) (map[string]string, error) {
+	input := secretsmanager.GetSecretValueInput{SecretId: aws.String(secretId)}
+	output, err := awsService.GetSecretValue(&input)
+	if err != nil {
+		return nil,
+			fmt.Errorf("error calling secretsmanager:GetSecretValue: %s", err)
+	}
+	if output.SecretString == nil {
+		return nil, errors.New("no SecretString in secret")
+	}
+	secret := []byte(*output.SecretString)
+	var secrets map[string]string
+	if err := json.Unmarshal(secret, &secrets); err != nil {
+		return nil, fmt.Errorf("error unmarshaling secret: %s", err)
+	}
+	return secrets, nil
+}
+
+func newLS(secretId string, logger log.DebugLogger) (*LockingStorer, error) {
+	awsService, err := getAwsService(secretId)
+	if err != nil {
+		return nil, err
+	}
+	return &LockingStorer{
+		awsService: awsService,
+		logger:     logger,
+		secretId:   secretId,
+	}, nil
+}
+
+func putAwsSecret(awsService *secretsmanager.SecretsManager,
+	secretId string, secrets map[string]string) error {
+	secretString, err := json.Marshal(secrets)
+	if err != nil {
+		return err
+	}
+	input := secretsmanager.PutSecretValueInput{
+		SecretId:     aws.String(secretId),
+		SecretString: aws.String(string(secretString)),
+	}
+	output, err := awsService.PutSecretValue(&input)
+	if err != nil {
+		return fmt.Errorf("error calling secretsmanager:PutSecretValue: %s",
+			err)
+	}
+	for _, versionStage := range output.VersionStages {
+		if *versionStage == "AWSCURRENT" {
+			return nil
+		}
+	}
+	return errors.New("no AWSCURRENT version stage associated")
+}
+
+func (ls *LockingStorer) lock() error {
+	ls.logger.Printf(
+		"UNIMPLEMENTED: locked AWS Secrets Manager, SecretId: %s\n",
+		ls.secretId)
+	return nil // HACK
+}
+
+func (ls *LockingStorer) read() (*certmanager.Certificate, error) {
+	keyMap, err := getAwsSecret(ls.awsService, ls.secretId)
+	if err != nil {
+		return nil, err
+	}
+	certPEM := &bytes.Buffer{}
+	for index := 0; ; index++ {
+		certificateBase64 := keyMap[fmt.Sprintf("Certificate%d", index)]
+		if certificateBase64 == "" {
+			if index == 0 {
+				return nil, errors.New("no Certificate in map")
+			}
+			break // We've reached the end of the certificate chain.
+		}
+		certDER, err := base64.StdEncoding.DecodeString(
+			strings.Replace(certificateBase64, " ", "", -1))
+		if err != nil {
+			return nil, err
+		}
+		if index != 0 {
+			fmt.Fprintln(certPEM)
+		}
+		err = pem.Encode(certPEM, &pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: certDER,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	keyType := keyMap["KeyType"]
+	if keyType == "" {
+		return nil, errors.New("no KeyType in map")
+	}
+	privateKeyBase64 := keyMap["PrivateKey"]
+	if privateKeyBase64 == "" {
+		return nil, errors.New("no PrivateKey in map")
+	}
+	privateKey, err := base64.StdEncoding.DecodeString(
+		strings.Replace(privateKeyBase64, " ", "", -1))
+	if err != nil {
+		return nil, err
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  keyType + " PRIVATE KEY",
+		Bytes: privateKey,
+	})
+	ls.logger.Printf(
+		"read certificate from AWS Secrets Manager, SecretId: %s\n",
+		ls.secretId)
+	return &certmanager.Certificate{
+		CertPemBlock: certPEM.Bytes(),
+		KeyPemBlock:  keyPEM,
+	}, nil
+}
+
+func (ls *LockingStorer) unlock() error {
+	ls.logger.Printf(
+		"UNIMPLEMENTED: unlocked AWS Secrets Manager, SecretId: %s\n",
+		ls.secretId)
+	return nil // HACK
+}
+
+func (ls *LockingStorer) write(cert *certmanager.Certificate) error {
+	keyMap := make(map[string]string, 4)
+	// Decode all the certificates in the chain.
+	next := cert.CertPemBlock
+	for index := 0; ; index++ {
+		var certBlock *pem.Block
+		certBlock, next = pem.Decode(next)
+		if certBlock == nil {
+			if index == 0 {
+				return errors.New("unable to decode any PEM Certificate")
+			}
+			break // We've reached the end of the certificate chain.
+		}
+		if certBlock.Type != "CERTIFICATE" {
+			return fmt.Errorf("Certificate type: %s not supported",
+				certBlock.Type)
+		}
+		keyMap[fmt.Sprintf("Certificate%d", index)] =
+			base64.StdEncoding.EncodeToString(certBlock.Bytes)
+	}
+	// Decode the private key.
+	keyBlock, _ := pem.Decode(cert.KeyPemBlock)
+	if keyBlock == nil {
+		return errors.New("unable to decode PEM PrivateKey")
+	}
+	splitKeyType := strings.SplitN(keyBlock.Type, " ", 2)
+	if len(splitKeyType) != 2 {
+		return fmt.Errorf("unable to split: %s", keyBlock.Type)
+	}
+	if splitKeyType[1] != "PRIVATE KEY" {
+		return fmt.Errorf("PrivateKey type: %s not supported", keyBlock.Type)
+	}
+	keyMap["KeyType"] = splitKeyType[0]
+	keyMap["PrivateKey"] = base64.StdEncoding.EncodeToString(keyBlock.Bytes)
+	if err := putAwsSecret(ls.awsService, ls.secretId, keyMap); err != nil {
+		return err
+	}
+	ls.logger.Printf("wrote certificate to AWS Secrets Manager, SecretId: %s\n",
+		ls.secretId)
+	return nil
+}

--- a/pkg/crypto/certmanager/storage/awssecretsmanager/impl.go
+++ b/pkg/crypto/certmanager/storage/awssecretsmanager/impl.go
@@ -26,6 +26,103 @@ var (
 	awsSecretsManagerMetadataClientError error
 )
 
+func decodeCert(encodedCert string) (*certmanager.Certificate, error) {
+	var keyMap map[string]string
+	if err := json.Unmarshal([]byte(encodedCert), &keyMap); err != nil {
+		return nil, fmt.Errorf("error unmarshaling secret: %s", err)
+	}
+	certPEM := &bytes.Buffer{}
+	for index := 0; ; index++ {
+		certificateBase64 := keyMap[fmt.Sprintf("Certificate%d", index)]
+		if certificateBase64 == "" {
+			if index == 0 {
+				return nil, errors.New("no Certificate in map")
+			}
+			break // We've reached the end of the certificate chain.
+		}
+		certDER, err := base64.StdEncoding.DecodeString(
+			strings.Replace(certificateBase64, " ", "", -1))
+		if err != nil {
+			return nil, err
+		}
+		if index != 0 {
+			fmt.Fprintln(certPEM)
+		}
+		err = pem.Encode(certPEM, &pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: certDER,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	keyType := keyMap["KeyType"]
+	if keyType != "" {
+		keyType += " "
+	}
+	privateKeyBase64 := keyMap["PrivateKey"]
+	if privateKeyBase64 == "" {
+		return nil, errors.New("no PrivateKey in map")
+	}
+	privateKey, err := base64.StdEncoding.DecodeString(
+		strings.Replace(privateKeyBase64, " ", "", -1))
+	if err != nil {
+		return nil, err
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  keyType + "PRIVATE KEY",
+		Bytes: privateKey,
+	})
+	return &certmanager.Certificate{
+		CertPemBlock: certPEM.Bytes(),
+		KeyPemBlock:  keyPEM,
+	}, nil
+}
+
+func encodeCert(cert *certmanager.Certificate) (string, error) {
+	keyMap := make(map[string]string, 4)
+	// Decode all the certificates in the chain.
+	next := cert.CertPemBlock
+	for index := 0; ; index++ {
+		var certBlock *pem.Block
+		certBlock, next = pem.Decode(next)
+		if certBlock == nil {
+			if index == 0 {
+				return "", errors.New("unable to decode any PEM Certificate")
+			}
+			break // We've reached the end of the certificate chain.
+		}
+		if certBlock.Type != "CERTIFICATE" {
+			return "", fmt.Errorf("Certificate type: %s not supported",
+				certBlock.Type)
+		}
+		keyMap[fmt.Sprintf("Certificate%d", index)] =
+			base64.StdEncoding.EncodeToString(certBlock.Bytes)
+	}
+	// Decode the private key.
+	keyBlock, _ := pem.Decode(cert.KeyPemBlock)
+	if keyBlock == nil {
+		return "", errors.New("unable to decode PEM PrivateKey")
+	}
+	if keyBlock.Type != "PRIVATE KEY" {
+		splitKeyType := strings.SplitN(keyBlock.Type, " ", 2)
+		if len(splitKeyType) != 2 {
+			return "", fmt.Errorf("unable to split: %s", keyBlock.Type)
+		}
+		if splitKeyType[1] != "PRIVATE KEY" {
+			return "", fmt.Errorf("PrivateKey type: %s not supported",
+				keyBlock.Type)
+		}
+		keyMap["KeyType"] = splitKeyType[0]
+	}
+	keyMap["PrivateKey"] = base64.StdEncoding.EncodeToString(keyBlock.Bytes)
+	encodedCert, err := json.Marshal(keyMap)
+	if err != nil {
+		return "", err
+	}
+	return string(encodedCert), nil
+}
+
 func getMetadataClient() (*ec2metadata.EC2Metadata, error) {
 	awsSecretsManagerLock.Lock()
 	defer awsSecretsManagerLock.Unlock()
@@ -72,22 +169,17 @@ func getAwsService(secretId string) (*secretsmanager.SecretsManager, error) {
 }
 
 func getAwsSecret(awsService *secretsmanager.SecretsManager,
-	secretId string) (map[string]string, error) {
+	secretId string) (string, error) {
 	input := secretsmanager.GetSecretValueInput{SecretId: aws.String(secretId)}
 	output, err := awsService.GetSecretValue(&input)
 	if err != nil {
-		return nil,
+		return "",
 			fmt.Errorf("error calling secretsmanager:GetSecretValue: %s", err)
 	}
 	if output.SecretString == nil {
-		return nil, errors.New("no SecretString in secret")
+		return "", errors.New("no SecretString in secret")
 	}
-	secret := []byte(*output.SecretString)
-	var secrets map[string]string
-	if err := json.Unmarshal(secret, &secrets); err != nil {
-		return nil, fmt.Errorf("error unmarshaling secret: %s", err)
-	}
-	return secrets, nil
+	return *output.SecretString, nil
 }
 
 func newLS(secretId string, logger log.DebugLogger) (*LockingStorer, error) {
@@ -103,14 +195,10 @@ func newLS(secretId string, logger log.DebugLogger) (*LockingStorer, error) {
 }
 
 func putAwsSecret(awsService *secretsmanager.SecretsManager,
-	secretId string, secrets map[string]string) error {
-	secretString, err := json.Marshal(secrets)
-	if err != nil {
-		return err
-	}
+	secretId string, secretString string) error {
 	input := secretsmanager.PutSecretValueInput{
 		SecretId:     aws.String(secretId),
-		SecretString: aws.String(string(secretString)),
+		SecretString: aws.String(secretString),
 	}
 	output, err := awsService.PutSecretValue(&input)
 	if err != nil {
@@ -126,96 +214,26 @@ func putAwsSecret(awsService *secretsmanager.SecretsManager,
 }
 
 func (ls *LockingStorer) read() (*certmanager.Certificate, error) {
-	keyMap, err := getAwsSecret(ls.awsService, ls.secretId)
+	secret, err := getAwsSecret(ls.awsService, ls.secretId)
 	if err != nil {
 		return nil, err
 	}
-	certPEM := &bytes.Buffer{}
-	for index := 0; ; index++ {
-		certificateBase64 := keyMap[fmt.Sprintf("Certificate%d", index)]
-		if certificateBase64 == "" {
-			if index == 0 {
-				return nil, errors.New("no Certificate in map")
-			}
-			break // We've reached the end of the certificate chain.
-		}
-		certDER, err := base64.StdEncoding.DecodeString(
-			strings.Replace(certificateBase64, " ", "", -1))
-		if err != nil {
-			return nil, err
-		}
-		if index != 0 {
-			fmt.Fprintln(certPEM)
-		}
-		err = pem.Encode(certPEM, &pem.Block{
-			Type:  "CERTIFICATE",
-			Bytes: certDER,
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
-	keyType := keyMap["KeyType"]
-	if keyType == "" {
-		return nil, errors.New("no KeyType in map")
-	}
-	privateKeyBase64 := keyMap["PrivateKey"]
-	if privateKeyBase64 == "" {
-		return nil, errors.New("no PrivateKey in map")
-	}
-	privateKey, err := base64.StdEncoding.DecodeString(
-		strings.Replace(privateKeyBase64, " ", "", -1))
+	cert, err := decodeCert(secret)
 	if err != nil {
 		return nil, err
 	}
-	keyPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  keyType + " PRIVATE KEY",
-		Bytes: privateKey,
-	})
 	ls.logger.Printf(
 		"read certificate from AWS Secrets Manager, SecretId: %s\n",
 		ls.secretId)
-	return &certmanager.Certificate{
-		CertPemBlock: certPEM.Bytes(),
-		KeyPemBlock:  keyPEM,
-	}, nil
+	return cert, nil
 }
 
 func (ls *LockingStorer) write(cert *certmanager.Certificate) error {
-	keyMap := make(map[string]string, 4)
-	// Decode all the certificates in the chain.
-	next := cert.CertPemBlock
-	for index := 0; ; index++ {
-		var certBlock *pem.Block
-		certBlock, next = pem.Decode(next)
-		if certBlock == nil {
-			if index == 0 {
-				return errors.New("unable to decode any PEM Certificate")
-			}
-			break // We've reached the end of the certificate chain.
-		}
-		if certBlock.Type != "CERTIFICATE" {
-			return fmt.Errorf("Certificate type: %s not supported",
-				certBlock.Type)
-		}
-		keyMap[fmt.Sprintf("Certificate%d", index)] =
-			base64.StdEncoding.EncodeToString(certBlock.Bytes)
+	secret, err := encodeCert(cert)
+	if err != nil {
+		return err
 	}
-	// Decode the private key.
-	keyBlock, _ := pem.Decode(cert.KeyPemBlock)
-	if keyBlock == nil {
-		return errors.New("unable to decode PEM PrivateKey")
-	}
-	splitKeyType := strings.SplitN(keyBlock.Type, " ", 2)
-	if len(splitKeyType) != 2 {
-		return fmt.Errorf("unable to split: %s", keyBlock.Type)
-	}
-	if splitKeyType[1] != "PRIVATE KEY" {
-		return fmt.Errorf("PrivateKey type: %s not supported", keyBlock.Type)
-	}
-	keyMap["KeyType"] = splitKeyType[0]
-	keyMap["PrivateKey"] = base64.StdEncoding.EncodeToString(keyBlock.Bytes)
-	if err := putAwsSecret(ls.awsService, ls.secretId, keyMap); err != nil {
+	if err := putAwsSecret(ls.awsService, ls.secretId, secret); err != nil {
 		return err
 	}
 	ls.logger.Printf("wrote certificate to AWS Secrets Manager, SecretId: %s\n",

--- a/pkg/crypto/certmanager/storage/awssecretsmanager/locker.go
+++ b/pkg/crypto/certmanager/storage/awssecretsmanager/locker.go
@@ -1,0 +1,129 @@
+package awssecretsmanager
+
+import (
+	"crypto/rand"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+)
+
+func sleep() {
+	randByte := make([]byte, 1)
+	rand.Read(randByte)
+	time.Sleep(time.Second*15 + time.Millisecond*10*time.Duration(randByte[0]))
+
+}
+
+// This must be called with the lock held.
+func (ls *LockingStorer) breakLock() error {
+	getInput := secretsmanager.GetSecretValueInput{
+		SecretId:     aws.String(ls.secretId),
+		VersionStage: aws.String("LOCK"),
+	}
+	getOutput, err := ls.awsService.GetSecretValue(&getInput)
+	if err != nil {
+		return fmt.Errorf("error calling secretsmanager:GetSecretValue: %s",
+			err)
+	}
+	// Remove LOCK label unless it's not time to break yet.
+	if getOutput.SecretString == nil {
+		ls.logger.Printf("no SecretString in SecretId: %s label: LOCK\n",
+			ls.secretId)
+	} else {
+		expirationEpoch, err := strconv.ParseInt(*getOutput.SecretString, 10,
+			64)
+		if err != nil {
+			ls.logger.Printf("error parsing epoch: \"%s\": %s\n",
+				*getOutput.SecretString, err)
+		} else if expirationEpoch > time.Now().Unix() {
+			return nil // Not yet time to break.
+		}
+	}
+	updateInput := secretsmanager.UpdateSecretVersionStageInput{
+		RemoveFromVersionId: getOutput.VersionId,
+		SecretId:            aws.String(ls.secretId),
+		VersionStage:        aws.String("LOCK"),
+	}
+	_, err = ls.awsService.UpdateSecretVersionStage(&updateInput)
+	if err != nil {
+		return fmt.Errorf("unable to remove LOCK label for SecretId: %s\n",
+			ls.secretId)
+	}
+	ls.logger.Printf("broke lock for SecretId: %s, version: %s\n",
+		ls.secretId, getOutput.VersionId)
+	return nil
+}
+
+func (ls *LockingStorer) lock() error {
+	ls.mutex.Lock()
+	defer ls.mutex.Unlock()
+	if ls.lockVersion != nil {
+		return fmt.Errorf("already locked SecretId: %s", ls.secretId)
+	}
+	expirationTime := time.Now().Add(time.Minute * 15)
+	putInput := secretsmanager.PutSecretValueInput{
+		SecretId:      aws.String(ls.secretId),
+		SecretString:  aws.String(fmt.Sprintf("%d", expirationTime.Unix())),
+		VersionStages: aws.StringSlice([]string{"DUMMY"}),
+	}
+	putOutput, err := ls.awsService.PutSecretValue(&putInput)
+	if err != nil {
+		return fmt.Errorf("error calling secretsmanager:PutSecretValue: %s",
+			err)
+	}
+	updateInput := secretsmanager.UpdateSecretVersionStageInput{
+		MoveToVersionId: putOutput.VersionId,
+		SecretId:        aws.String(ls.secretId),
+		VersionStage:    aws.String("LOCK"),
+	}
+	for {
+		_, err := ls.awsService.UpdateSecretVersionStage(&updateInput)
+		if err == nil {
+			ls.lockVersion = putOutput.VersionId
+			break
+		}
+		ls.logger.Debugf(0,
+			"error grabbing lock for SecretId: %s, waiting: %s\n",
+			ls.secretId, err)
+		sleep()
+		if err := ls.breakLock(); err != nil {
+			ls.logger.Println(err)
+		}
+	}
+	updateInput = secretsmanager.UpdateSecretVersionStageInput{
+		RemoveFromVersionId: putOutput.VersionId,
+		SecretId:            aws.String(ls.secretId),
+		VersionStage:        aws.String("DUMMY"),
+	}
+	_, err = ls.awsService.UpdateSecretVersionStage(&updateInput)
+	if err != nil {
+		ls.logger.Printf("unable to remove DUMMY label for SecretId: %s\n",
+			ls.secretId)
+	}
+	ls.logger.Printf("locked AWS Secrets Manager, SecretId: %s\n", ls.secretId)
+	return nil
+}
+
+func (ls *LockingStorer) unlock() error {
+	ls.mutex.Lock()
+	defer ls.mutex.Unlock()
+	if ls.lockVersion == nil {
+		return fmt.Errorf("already unlocked SecretId: %s", ls.secretId)
+	}
+	updateInput := secretsmanager.UpdateSecretVersionStageInput{
+		RemoveFromVersionId: ls.lockVersion,
+		SecretId:            aws.String(ls.secretId),
+		VersionStage:        aws.String("LOCK"),
+	}
+	_, err := ls.awsService.UpdateSecretVersionStage(&updateInput)
+	if err != nil {
+		return fmt.Errorf("unable to remove LOCK label for SecretId: %s",
+			ls.secretId)
+	}
+	ls.logger.Printf("unlocked AWS Secrets Manager, SecretId: %s\n",
+		ls.secretId)
+	return nil
+}

--- a/pkg/crypto/certmanager/storage/awssecretsmanager/locker.go
+++ b/pkg/crypto/certmanager/storage/awssecretsmanager/locker.go
@@ -53,7 +53,7 @@ func (ls *LockingStorer) breakLock() error {
 			ls.secretId)
 	}
 	ls.logger.Printf("broke lock for SecretId: %s, version: %s\n",
-		ls.secretId, getOutput.VersionId)
+		ls.secretId, *getOutput.VersionId)
 	return nil
 }
 

--- a/pkg/crypto/certmanager/storage/awssecretsmanager/storer_test.go
+++ b/pkg/crypto/certmanager/storage/awssecretsmanager/storer_test.go
@@ -1,0 +1,86 @@
+package awssecretsmanager
+
+import (
+	"testing"
+
+	"github.com/Cloud-Foundations/golib/pkg/crypto/certmanager"
+)
+
+const (
+	testTypedKeyPEM = `-----BEGIN EC PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgXHeJ5aXDEz7zB7uS
+k+1WujTeYzAzBgvtpOhj2mgRJdKhRANCAAQKE5puaIhI6HbXfmDpdkUimOAlVrxC
+nS76isEgnr3vLchNIsWMN/94z5eMTi+bX/uQDDA5grTIETCDDBJJG/c3
+-----END EC PRIVATE KEY-----
+`
+	testUntypedKeyPEM = `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgXHeJ5aXDEz7zB7uS
+k+1WujTeYzAzBgvtpOhj2mgRJdKhRANCAAQKE5puaIhI6HbXfmDpdkUimOAlVrxC
+nS76isEgnr3vLchNIsWMN/94z5eMTi+bX/uQDDA5grTIETCDDBJJG/c3
+-----END PRIVATE KEY-----
+`
+	testCertificatePEM = `-----BEGIN CERTIFICATE-----
+MIIBFDCBvAIBATAKBggqhkjOPQQDAjARMQ8wDQYDVQQDDAZUZXN0Q0EwIBcNMjAw
+MzE1MDcwOTMwWhgPMjEyMDAyMjAwNzA5MzBaMBsxGTAXBgNVBAMMEFRlc3RJbnRl
+cm1lZGlhdGUwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQKE5puaIhI6HbXfmDp
+dkUimOAlVrxCnS76isEgnr3vLchNIsWMN/94z5eMTi+bX/uQDDA5grTIETCDDBJJ
+G/c3MAoGCCqGSM49BAMCA0cAMEQCIBYWw2ybx/ueMws2wNqEC8XtplGY8HZCA39z
+S4nRrcukAiAX4PWy66NoUQGKOZsGHRKpUKNQua7KG7ysO33e+af6iw==
+-----END CERTIFICATE-----
+
+-----BEGIN CERTIFICATE-----
+MIIBCzCBsgIBATAKBggqhkjOPQQDAjARMQ8wDQYDVQQDDAZUZXN0Q0EwIBcNMjAw
+MzE1MDY1MzMwWhgPMjEyMDAyMjAwNjUzMzBaMBExDzANBgNVBAMMBlRlc3RDQTBZ
+MBMGByqGSM49AgEGCCqGSM49AwEHA0IABHiyyDcrn5EMM58Be6viTu78UQHPWJvX
+mBLDZz5i2ILLB1WF/KqeqkxlI3NhHyBbBlf0NF89ow9LNhXaHvtIkzwwCgYIKoZI
+zj0EAwIDSAAwRQIhAMmltED4JLMZtowVLyFCS4ow3O6X9OKK3moaCzR6Qd6HAiAY
+QjzMX8HJLQHLGYHb3FEv04EIG51pDmcPwa19BAEiLw==
+-----END CERTIFICATE-----
+`
+)
+
+func TestTypedKey(t *testing.T) {
+	testCert := &certmanager.Certificate{
+		CertPemBlock: []byte(testCertificatePEM),
+		KeyPemBlock:  []byte(testTypedKeyPEM),
+	}
+	encodedCert, err := encodeCert(testCert)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decodedCert, err := decodeCert(encodedCert)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(decodedCert.CertPemBlock) != string(testCert.CertPemBlock) {
+		t.Fatalf("decoded cert PEM: %s != test PEM: %s",
+			string(decodedCert.CertPemBlock), string(testCert.CertPemBlock))
+	}
+	if string(decodedCert.KeyPemBlock) != string(testCert.KeyPemBlock) {
+		t.Fatalf("decoded key PEM: %s != test PEM: %s",
+			string(decodedCert.KeyPemBlock), string(testCert.KeyPemBlock))
+	}
+}
+
+func TestUntypedKey(t *testing.T) {
+	testCert := &certmanager.Certificate{
+		CertPemBlock: []byte(testCertificatePEM),
+		KeyPemBlock:  []byte(testUntypedKeyPEM),
+	}
+	encodedCert, err := encodeCert(testCert)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decodedCert, err := decodeCert(encodedCert)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(decodedCert.CertPemBlock) != string(testCert.CertPemBlock) {
+		t.Fatalf("decoded cert PEM: %s != test PEM: %s",
+			string(decodedCert.CertPemBlock), string(testCert.CertPemBlock))
+	}
+	if string(decodedCert.KeyPemBlock) != string(testCert.KeyPemBlock) {
+		t.Fatalf("decoded key PEM: %s != test PEM: %s",
+			string(decodedCert.KeyPemBlock), string(testCert.KeyPemBlock))
+	}
+}


### PR DESCRIPTION
This change supports using AWS Secrets Manager for storing and retrieving certificates and for ACME transaction locking. With this change it should be safe to start multiple service instances at the same time; the first to obtain the lock will perform and complete the certificate request and as each of the other instances obtains the lock they will fetch the stored certificate. 