### PR TITLE
Fix pkg/crypto/certmanager/encoding/impl_test.go package name

### DIFF
--- a/pkg/crypto/certmanager/encoding/impl_test.go
+++ b/pkg/crypto/certmanager/encoding/impl_test.go
@@ -1,4 +1,4 @@
-package awssecretsmanager
+package encoding
 
 import (
 	"testing"


### PR DESCRIPTION
```
$ GO111MODULE=off make test
ok      github.com/Cloud-Foundations/golib/pkg/auth/ldaputil    (cached)
ok      github.com/Cloud-Foundations/golib/pkg/auth/userinfo/filter     (cached)
ok      github.com/Cloud-Foundations/golib/pkg/auth/userinfo/gitdb      (cached)
ok      github.com/Cloud-Foundations/golib/pkg/crypto/certmanager/encoding   (cached)
ok      github.com/Cloud-Foundations/golib/pkg/watchdog (cached)
```