### PR TITLE
pkg/auth/oidc: fix support for large group lists.

### DIFF
--- a/cmd/show-auth-cert/main.go
+++ b/cmd/show-auth-cert/main.go
@@ -51,34 +51,7 @@ func showCert(filename string) {
 		fmt.Fprintln(os.Stderr, err)
 		return
 	}
-	if authInfo.Username != "" {
-		fmt.Printf("  Issued to user: %s\n", authInfo.Username)
-	} else if authInfo.AwsRole != nil {
-		fmt.Printf("  Issued to AWS role: %s in account: %s (ARN=%s)\n",
-			authInfo.AwsRole.Name, authInfo.AwsRole.AccountId,
-			authInfo.AwsRole.ARN)
-	} else {
-		fmt.Printf("  Issued to unknown principal: %s\n",
-			cert.Subject.CommonName)
-	}
-	if len(authInfo.PermittedMethods) > 0 {
-		fmt.Println("  Permitted methods:")
-		showList(authInfo.PermittedMethods)
-	} else {
-		fmt.Println("  No methods are permitted")
-	}
-	if len(authInfo.Groups) > 0 {
-		fmt.Println("  Group list:")
-		showList(authInfo.Groups)
-	} else {
-		fmt.Println("  No group memberships")
-	}
-}
-
-func showList(list []string) {
-	for _, entry := range list {
-		fmt.Println("   ", entry)
-	}
+	authInfo.Write(os.Stdout, "  ", " ", "")
 }
 
 func main() {

--- a/pkg/auth/oidc/impl.go
+++ b/pkg/auth/oidc/impl.go
@@ -25,11 +25,11 @@ import (
 )
 
 const (
-	cookieNamePrefix              = "authn_cookie"
+	cookieNamePrefix              = "cf_golib_oidc_authn_cookie"
 	secondsBetweenCleanup         = 60
 	cookieExpirationHours         = 3
 	maxAgeSecondsRedirCookie      = 120
-	redirCookieName               = "oauth2_redir"
+	redirCookieName               = "cf_golib_oidc_oauth2_redir"
 	oauth2redirectPath            = "/oauth2/redirectendpoint"
 	authNCookieExpirationDuration = 12 * time.Hour
 )


### PR DESCRIPTION
Move group information for the user from the `authn_cookie` to an internal expiring cache.
Add debugging output.
show-auth-cert: use new `pkg/auth/authinfo.AuthInfo.Write()` method.